### PR TITLE
Přidání stránky pro správu přírodnin

### DIFF
--- a/Controllers/Menu/Management/ClassObject/ManageController.php
+++ b/Controllers/Menu/Management/ClassObject/ManageController.php
@@ -100,6 +100,7 @@ class ManageController extends Controller
             $this->pageHeader['jsFiles'] = array('js/generic.js', 'js/menu.js', 'js/ajaxMediator.js','js/manage.js');
             $this->pageHeader['bodyId'] = 'manage';
 
+            $this->data['baseUrl'] = 'menu/'.$_SESSION['selection']['class']->getUrl().'/manage';
             $this->data['classId'] = $_SESSION['selection']['class']->getId();
             $this->data['className'] = $_SESSION['selection']['class']->getName();
             $this->data['classStatus'] = $_SESSION['selection']['class']->getStatus();

--- a/Controllers/Menu/Management/ClassObject/ManageController.php
+++ b/Controllers/Menu/Management/ClassObject/ManageController.php
@@ -88,8 +88,6 @@ class ManageController extends Controller
             $this->pageHeader['bodyId'] = $this->controllerToCall->pageHeader['bodyId'];
             $this->data['navigationBar'] = array_merge($this->data['navigationBar'], $this->controllerToCall->data['navigationBar']);
 
-            $this->data['returnButtonLink'] = $this->controllerToCall->data['returnButtonLink'];
-            
             $this->view = 'inherit';
         }
         else

--- a/Controllers/Menu/Management/ClassObject/MembersController.php
+++ b/Controllers/Menu/Management/ClassObject/MembersController.php
@@ -38,8 +38,7 @@ class MembersController extends Controller
             )
         );
         $this->data['members'] = $_SESSION['selection']['class']->getMembers(false); //false zajistí, že se nezobrazí právě přihlášený uživatel
-        $this->data['returnButtonLink'] = 'menu/'.$_SESSION['selection']['class']->getUrl().'/manage';
-        
+
         $this->view = 'members';
     }
 }

--- a/Controllers/Menu/Management/ClassObject/NaturalsController.php
+++ b/Controllers/Menu/Management/ClassObject/NaturalsController.php
@@ -1,0 +1,35 @@
+<?php
+namespace Poznavacky\Controllers\Menu\Management\ClassObject;
+
+use Poznavacky\Controllers\Controller;
+
+/**
+ * Kontroler starající se o výpis stránky pro správu přírodnin třídy jejím správcům
+ * @author Jan Štěch
+ */
+class NaturalsController extends Controller
+{
+
+    /**
+     * Metoda nastavující hlavičku stránky, data pro pohled a pohled
+     * @see Controller::process()
+     */
+    function process(array $parameters): void
+    {
+        $this->pageHeader['title'] = 'Správa přírodnin';
+        $this->pageHeader['description'] = 'Nástroj pro správce tříd umožňující snadnou správu přírodnin';
+        $this->pageHeader['keywords'] = '';
+        $this->pageHeader['cssFiles'] = array('css/css.css');
+        $this->pageHeader['jsFiles'] = array('js/generic.js', 'js/menu.js', 'js/ajaxMediator.js','js/naturals.js');
+        $this->pageHeader['bodyId'] = 'naturals';
+        $this->data['navigationBar'] = array(
+            0 => array(
+                'text' => $this->pageHeader['title'],
+                'link' => 'menu/'.$_SESSION['selection']['class']->getUrl().'/manage/naturals'
+            )
+        );
+        $this->data['naturals'] = $_SESSION['selection']['class']->getNaturals();
+
+        $this->view = 'naturals';
+    }
+}

--- a/Controllers/Menu/Management/ClassObject/TestsController.php
+++ b/Controllers/Menu/Management/ClassObject/TestsController.php
@@ -96,7 +96,6 @@ class TestsController extends Controller
             $this->pageHeader['jsFiles'] = $this->controllerToCall->pageHeader['jsFiles'];
             $this->pageHeader['bodyId'] = $this->controllerToCall->pageHeader['bodyId'];
             $this->data['navigationBar'] = array_merge($this->data['navigationBar'], $this->controllerToCall->data['navigationBar']);
-            $this->data['returnButtonLink'] = $this->controllerToCall->data['returnButtonLink'];
             
             $this->view = 'inherit';
         }

--- a/Controllers/Menu/Management/ClassObject/UpdateNaturalsController.php
+++ b/Controllers/Menu/Management/ClassObject/UpdateNaturalsController.php
@@ -1,0 +1,85 @@
+<?php
+namespace Poznavacky\Controllers\Menu\Management\ClassObject;
+
+use Poznavacky\Controllers\Controller;
+use Poznavacky\Models\Exceptions\AccessDeniedException;
+use Poznavacky\Models\Security\AccessChecker;
+use Poznavacky\Models\Statics\UserManager;
+use Poznavacky\Models\AjaxResponse;
+
+/**
+ * Kontroler zpracovávající data odeslaná ze stránky manage
+ * @author Jan Štěch
+ */
+class UpdateNaturalsController extends Controller
+{
+    /**
+     * Metoda odlišující, jakou akci si přeje správce třídy provést a volající příslušný model
+     * @see Controller::process()
+     */
+    public function process(array $parameters): void
+    {
+        if (empty($_POST))
+        {
+            header('HTTP/1.0 400 Bad Request');
+            exit();
+        }
+        
+        header('Content-Type: application/json');
+        //Kontrola, zda je zvolena nějaká třída
+        if (!isset($_SESSION['selection']['class']))
+        {
+            $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_ERROR, AccessDeniedException::REASON_CLASS_NOT_CHOSEN, array('origin' => $_POST['action']));
+            echo $response->getResponseString();
+            exit();
+        }
+        $class = $_SESSION['selection']['class'];
+        
+        //Kontrola, zda je nějaký uživatel přihlášen a zda je přihlášený uživatel správcem vybrané třídy nebo systémový administrátor
+        $aChecker = new AccessChecker();
+        if (!$aChecker->checkUser() || !($class->checkAdmin(UserManager::getId()) || $aChecker->checkSystemAdmin()))
+        {
+            header('HTTP/1.0 403 Forbidden');
+            exit();
+        }
+        
+        try
+        {
+            switch ($_POST['action'])
+            {
+                case 'rename':
+                    $naturalId = $_POST['naturalId'];
+                    $newName = $_POST['newName'];
+                    //TODO
+                    $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_SUCCESS, 'Přírodnina úspěšně přejmenována');
+                    echo $response->getResponseString();
+                    break;
+                case 'merge':
+                    $fromNaturalId = $_POST['fromNaturalId'];
+                    $toNaturalId = $_POST['toNaturalId'];
+                    //TODO
+                    $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_SUCCESS, 'Přírodniny úspěšně sloučeny a obrázky převedeny');
+                    echo $response->getResponseString();
+                    break;
+                case 'delete':
+                    $naturalId = $_POST['naturalId'];
+                    //TODO
+                    $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_SUCCESS, 'Přírodnina úspěšně odstraněna');
+                    echo $response->getResponseString();
+                    break;
+                default:
+                    header('HTTP/1.0 400 Bad Request');
+                    exit();
+            }
+        }
+        catch (AccessDeniedException $e)
+        {
+            $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_ERROR, $e->getMessage(), array('origin' => $_POST['action']));
+            echo $response->getResponseString();
+        }
+        
+        //Zastav zpracování PHP, aby se nevypsala šablona
+        exit();
+    }
+}
+

--- a/Controllers/Menu/Management/ClassObject/UpdateNaturalsController.php
+++ b/Controllers/Menu/Management/ClassObject/UpdateNaturalsController.php
@@ -64,8 +64,8 @@ class UpdateNaturalsController extends Controller
                     $toNaturalId = $_POST['toNaturalId'];
                     $fromNatural = new Natural(false, $fromNaturalId);
                     $toNatural = new Natural(false, $toNaturalId);
-                    $editor->merge($fromNatural, $toNatural);
-                    $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_SUCCESS, 'Přírodniny úspěšně sloučeny a obrázky převedeny');
+                    $mergeResult = $editor->merge($fromNatural, $toNatural);
+                    $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_SUCCESS, 'Přírodniny úspěšně sloučeny a obrázky převedeny', array('newUsesCount' => $mergeResult['mergedUses'], 'newPicturesCount' => $mergeResult['mergedPictures']));
                     echo $response->getResponseString();
                     break;
                 case 'delete':

--- a/Controllers/Menu/Management/ClassObject/UpdateNaturalsController.php
+++ b/Controllers/Menu/Management/ClassObject/UpdateNaturalsController.php
@@ -2,7 +2,9 @@
 namespace Poznavacky\Controllers\Menu\Management\ClassObject;
 
 use Poznavacky\Controllers\Controller;
+use Poznavacky\Models\DatabaseItems\Natural;
 use Poznavacky\Models\Exceptions\AccessDeniedException;
+use Poznavacky\Models\Processors\NaturalEditor;
 use Poznavacky\Models\Security\AccessChecker;
 use Poznavacky\Models\Statics\UserManager;
 use Poznavacky\Models\AjaxResponse;
@@ -24,7 +26,7 @@ class UpdateNaturalsController extends Controller
             header('HTTP/1.0 400 Bad Request');
             exit();
         }
-        
+
         header('Content-Type: application/json');
         //Kontrola, zda je zvolena nějaká třída
         if (!isset($_SESSION['selection']['class']))
@@ -34,7 +36,7 @@ class UpdateNaturalsController extends Controller
             exit();
         }
         $class = $_SESSION['selection']['class'];
-        
+
         //Kontrola, zda je nějaký uživatel přihlášen a zda je přihlášený uživatel správcem vybrané třídy nebo systémový administrátor
         $aChecker = new AccessChecker();
         if (!$aChecker->checkUser() || !($class->checkAdmin(UserManager::getId()) || $aChecker->checkSystemAdmin()))
@@ -42,28 +44,34 @@ class UpdateNaturalsController extends Controller
             header('HTTP/1.0 403 Forbidden');
             exit();
         }
-        
+
         try
         {
+            $editor = new NaturalEditor($class);
+
             switch ($_POST['action'])
             {
                 case 'rename':
                     $naturalId = $_POST['naturalId'];
                     $newName = $_POST['newName'];
-                    //TODO
+                    $natural = new Natural(false, $naturalId);
+                    $editor->rename($natural, $newName);
                     $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_SUCCESS, 'Přírodnina úspěšně přejmenována');
                     echo $response->getResponseString();
                     break;
                 case 'merge':
                     $fromNaturalId = $_POST['fromNaturalId'];
                     $toNaturalId = $_POST['toNaturalId'];
-                    //TODO
+                    $fromNatural = new Natural(false, $fromNaturalId);
+                    $toNatural = new Natural(false, $toNaturalId);
+                    $editor->merge($fromNatural, $toNatural);
                     $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_SUCCESS, 'Přírodniny úspěšně sloučeny a obrázky převedeny');
                     echo $response->getResponseString();
                     break;
                 case 'delete':
                     $naturalId = $_POST['naturalId'];
-                    //TODO
+                    $natural = new Natural(false, $naturalId);
+                    $editor->delete($natural);
                     $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_SUCCESS, 'Přírodnina úspěšně odstraněna');
                     echo $response->getResponseString();
                     break;
@@ -77,7 +85,7 @@ class UpdateNaturalsController extends Controller
             $response = new AjaxResponse(AjaxResponse::MESSAGE_TYPE_ERROR, $e->getMessage(), array('origin' => $_POST['action']));
             echo $response->getResponseString();
         }
-        
+
         //Zastav zpracování PHP, aby se nevypsala šablona
         exit();
     }

--- a/Models/DatabaseItems/ClassObject.php
+++ b/Models/DatabaseItems/ClassObject.php
@@ -159,7 +159,7 @@ class ClassObject extends Folder
         $result = Db::fetchQuery('SELECT '.Natural::COLUMN_DICTIONARY['id'].','.Natural::COLUMN_DICTIONARY['name'].','.Natural::COLUMN_DICTIONARY['picturesCount'].',(SELECT COUNT(*) FROM prirodniny_casti WHERE prirodniny_id = '.Natural::TABLE_NAME.'.'.Natural::COLUMN_DICTIONARY['id'].') AS "uses" FROM '.Natural::TABLE_NAME.' WHERE '.Natural::COLUMN_DICTIONARY['class'].' = ?;', array($this->id), true);
         if ($result === false || count($result) === 0)
         {
-            //Žádné poznávačky nenalezeny
+            //Žádné přírodniny nenalezeny
             return array();
         }
         else

--- a/Models/DatabaseItems/ClassObject.php
+++ b/Models/DatabaseItems/ClassObject.php
@@ -156,7 +156,7 @@ class ClassObject extends Folder
     public function getNaturals(): array
     {
         $this->loadIfNotLoaded($this->id);
-        $result = Db::fetchQuery('SELECT '.Natural::COLUMN_DICTIONARY['id'].','.Natural::COLUMN_DICTIONARY['name'].','.Natural::COLUMN_DICTIONARY['picturesCount'].' FROM '.Natural::TABLE_NAME.' WHERE '.Natural::COLUMN_DICTIONARY['class'].' = ?;', array($this->id), true);
+        $result = Db::fetchQuery('SELECT '.Natural::COLUMN_DICTIONARY['id'].','.Natural::COLUMN_DICTIONARY['name'].','.Natural::COLUMN_DICTIONARY['picturesCount'].',(SELECT COUNT(*) FROM prirodniny_casti WHERE prirodniny_id = '.Natural::TABLE_NAME.'.'.Natural::COLUMN_DICTIONARY['id'].') AS "uses" FROM '.Natural::TABLE_NAME.' WHERE '.Natural::COLUMN_DICTIONARY['class'].' = ?;', array($this->id), true);
         if ($result === false || count($result) === 0)
         {
             //Žádné poznávačky nenalezeny
@@ -169,7 +169,7 @@ class ClassObject extends Folder
             {
                 $natural = new Natural(false, $naturalData[Natural::COLUMN_DICTIONARY['id']]);
                 //Místo posledního null by se mělo nastavit $this, avšak výsledné pole obsahuje příliš mnoho úrovní vnořených objektů a jeho ošetření proti XSS útoku trvá strašně dlouho
-                $natural->initialize($naturalData[Natural::COLUMN_DICTIONARY['name']], null, $naturalData[Natural::COLUMN_DICTIONARY['picturesCount']], null);
+                $natural->initialize($naturalData[Natural::COLUMN_DICTIONARY['name']], null, $naturalData[Natural::COLUMN_DICTIONARY['picturesCount']], null, null, $naturalData['uses']);
                 $naturals[] = $natural;
             }
         }

--- a/Models/DatabaseItems/Group.php
+++ b/Models/DatabaseItems/Group.php
@@ -153,6 +153,7 @@ class Group extends Folder
                 )
             );
         ', array($this->id), true);
+        if ($result === false) { $result = array(); /*Žádné přírodniny nenalezeny*/ }
         foreach ($result as $naturalData)
         {
             $natural = new Natural(false, $naturalData[Natural::COLUMN_DICTIONARY['id']]);

--- a/Models/DatabaseItems/Group.php
+++ b/Models/DatabaseItems/Group.php
@@ -295,7 +295,7 @@ class Group extends Folder
     /**
      * Metoda nastavující poznávačce nový název a podle něj aktualizuje i URL
      * Počítá se s tím, že jméno již bylo ošetřeno na délku, znaky a unikátnost
-     * Změna není uložena do databáze, aby bylo nové jméno trvale uloženo, musí být zavolána metoda Gruop::save()
+     * Změna není uložena do databáze, aby bylo nové jméno trvale uloženo, musí být zavolána metoda Group::save()
      * @param string $newName Nový název třídy
      */
     public function rename(string $newName): void

--- a/Models/DatabaseItems/Natural.php
+++ b/Models/DatabaseItems/Natural.php
@@ -4,38 +4,41 @@ namespace Poznavacky\Models\DatabaseItems;
 use Poznavacky\Models\Statics\Db;
 use Poznavacky\Models\undefined;
 
-/** 
+/**
  * Třída reprezentující objekt přírodniny
  * @author Jan Štěch
  */
 class Natural extends DatabaseItem
 {
     public const TABLE_NAME = 'prirodniny';
-    
+
     public const COLUMN_DICTIONARY = array(
         'id' => 'prirodniny_id',
         'name' => 'nazev',
         'picturesCount' => 'obrazky',
         'class' => 'tridy_id'
     );
-    
+
     protected const NON_PRIMITIVE_PROPERTIES = array(
         'class' => ClassObject::class
     );
-    
+
     protected const DEFAULT_VALUES = array(
-        'picturesCount' => 0
+        'picturesCount' => 0,
+        'usesCount' => 0
     );
-    
+
     protected const CAN_BE_CREATED = true;
     protected const CAN_BE_UPDATED = true;
-    
+
     protected $name;
     protected $picturesCount;
     protected $class;
 
     protected $pictures;
-    
+    protected $uses;
+    protected $usesCount;
+
     /**
      * Metoda nastavující všechny vlasnosti objektu (s výjimkou ID) podle zadaných argumentů
      * Při nastavení některého z argumentů na undefined, je hodnota dané vlastnosti také nastavena na undefined
@@ -44,10 +47,12 @@ class Natural extends DatabaseItem
      * @param Picture[]|undefined|null $pictures Pole obrázků nahraných k této přírodnině, jako objekty
      * @param int|undefined|null $picturesCount Počet obrázků nahraných k této přírodnině (při vyplnění parametru $pictures je ignorováno a je použita délka poskytnutého pole)
      * @param ClassObject|undefined|null $class Třída, se kterou je tato přírodnina svázána
+     * @param Part[]|undefined|null $uses Pole částí poznávaček, ve kterých je tato přírodnina používána
+     * @param int|undefined|null $usesCount Počet částí poznávaček, ve kterých je tato přírodnina využívána (při vyplnění parametru $uses je ignorováno a je použita délka poskytnutého pole)
      * {@inheritDoc}
      * @see DatabaseItem::initialize()
      */
-    public function initialize($name = null, $pictures = null, $picturesCount = null, $class = null): void
+    public function initialize($name = null, $pictures = null, $picturesCount = null, $class = null, $uses = null, $usesCount = null): void
     {
         //Kontrola nespecifikovaných hodnot (pro zamezení přepsání známých hodnot)
         if ($name === null){ $name = $this->name; }
@@ -58,13 +63,19 @@ class Natural extends DatabaseItem
         }
         else { $picturesCount = count($pictures); }
         if ($class === null){ $class = $this->class; }
-        
+        if ($uses === null)
+        {
+            $uses = $this->uses;
+            if ($usesCount === null){ $usesCount = $this->usesCount; }
+        }
+        else { $usesCount = count($uses); }
+
         $this->name = $name;
         $this->pictures = $pictures;
         $this->picturesCount = $picturesCount;
         $this->class = $class;
     }
-        
+
     /**
      * Metoda navracející jméno této přírodniny
      * @return string Jméno přírodniny
@@ -74,7 +85,7 @@ class Natural extends DatabaseItem
         $this->loadIfNotLoaded($this->name);
         return $this->name;
     }
-    
+
     /**
      * Metoda navracející objekt třídy, do které tato přírodnina patří
      * @return ClassObject Třída, se kterou je tato přírodnina svázána
@@ -84,7 +95,7 @@ class Natural extends DatabaseItem
         $this->loadIfNotLoaded($this->class);
         return $this->class;
     }
-    
+
     /**
      * Metoda navracející počet obrázků této přírodniny
      * @return int Počet obrázků této přírodniny uložené v databázi
@@ -105,7 +116,7 @@ class Natural extends DatabaseItem
         if (!$this->isDefined($this->pictures)){ $this->loadPictures(); }
         return $this->pictures;
     }
-    
+
     /**
      * Metoda navracející náhodný obrázek této příodniny jako objekt
      * Pokud zatím nebyly adresy načteny z databáze, budou načteny.
@@ -183,6 +194,55 @@ class Natural extends DatabaseItem
             }
         }
         return false;
+    }
+
+    /**
+     * Metoda navracející počet částí, ve kterých je tato přírodnina používána
+     * @return int Počet částí, které obsahují tuto přírodninu
+     */
+    public function getUsesCount(): int
+    {
+        if (!$this->isDefined($this->usesCount)){ $this->loadUses(); }
+        return $this->usesCount;
+    }
+
+    /**
+     * Metoda navracející pole všech částí, ve kterých je tato přírodnina používána
+     * Pokud zatím nebyl seznam částí načten z databáze, bude načten.
+     * @return Part[] Pole částí, ve kterých je tato přírodnina využívána, jako objekty
+     */
+    public function getUses(): array
+    {
+        if (!$this->isDefined($this->uses)){ $this->loadUses(); }
+        return $this->uses;
+    }
+
+    /**
+     * Metoda načítající z databáze části, ve kterých je přírodnina použita a ukládající je jako vlastnost objektu
+     * Vlastnost $usesCount je nastavena / upravena podle počtu načtených obrázků
+     */
+    public function loadUses(): void
+    {
+        $this->loadIfNotLoaded($this->id);
+
+        $result = Db::fetchQuery('SELECT '.Part::COLUMN_DICTIONARY['id'].', '.Part::COLUMN_DICTIONARY['name'].', '.Part::COLUMN_DICTIONARY['url'].', '.Part::COLUMN_DICTIONARY['group'].' FROM '.Part::TABLE_NAME.' WHERE '.Part::COLUMN_DICTIONARY['id'].' IN (SELECT casti_id FROM prirodniny_casti WHERE prirodniny_id = ?)', array($this->id), true);
+        if ($result === false || count($result) === 0)
+        {
+            //Žádná využití nenalezena
+            $this->uses = array();
+        }
+        else
+        {
+            $this->uses = array();
+
+            foreach ($result as $partData)
+            {
+                $part = new Part(false, $partData[Part::COLUMN_DICTIONARY['id']]);
+                $part->initialize($partData[Part::COLUMN_DICTIONARY['name']], $partData[Part::COLUMN_DICTIONARY['url']], $partData[Part::COLUMN_DICTIONARY['group']]);
+                $this->uses[] = $part;
+            }
+        }
+        $this->usesCount = count($this->uses);
     }
 }
 

--- a/Models/DatabaseItems/Picture.php
+++ b/Models/DatabaseItems/Picture.php
@@ -5,6 +5,7 @@ use Poznavacky\Models\Exceptions\AccessDeniedException;
 use Poznavacky\Models\Processors\PictureAdder;
 use Poznavacky\Models\Statics\Db;
 use Poznavacky\Models\undefined;
+use \RuntimeException;
 
 /** 
  * Třída reprezentující objekt obrázku
@@ -120,11 +121,17 @@ class Picture extends DatabaseItem
     /**
      * Metoda převádějící tento obrázek k jiné přírodnině
      * Není kontrolováno, zda nová přírodnina patří do té samé třídy, jako ta stávající
+     * Je provedena kontrola, zda obrázek s danou URL již není přidán k nové přírodnině
      * Změny nejsou uloženy do databáze, aby se tak stalo, musí být zavolána metoda Picture::save()
      * @param Natural $newNatural Objekt přírodniny, ke které má být tento obrázek převeden
+     * @throws RuntimeException Pokud je tento obrázek již ke specifikované přírodnině přidán
      */
     public function transfer(Natural $newNatural): void
     {
+        if ($newNatural->pictureExists($this->getSrc()))
+        {
+            throw new RuntimeException('Picture with this URL is already added to the new natural.');
+        }
         $this->natural = $newNatural;
     }
 

--- a/Models/DatabaseItems/Picture.php
+++ b/Models/DatabaseItems/Picture.php
@@ -116,7 +116,18 @@ class Picture extends DatabaseItem
         
         return true;
     }
-    
+
+    /**
+     * Metoda převádějící tento obrázek k jiné přírodnině
+     * Není kontrolováno, zda nová přírodnina patří do té samé třídy, jako ta stávající
+     * Změny nejsou uloženy do databáze, aby se tak stalo, musí být zavolána metoda Picture::save()
+     * @param Natural $newNatural Objekt přírodniny, ke které má být tento obrázek převeden
+     */
+    public function transfer(Natural $newNatural): void
+    {
+        $this->natural = $newNatural;
+    }
+
     /**
      * Metoda navracející pole hlášení tohoto obrázku
      * Pokud hlášení zatím nebyla načtena z databáze, budou před navrácením načtena

--- a/Models/Exceptions/AccessDeniedException.php
+++ b/Models/Exceptions/AccessDeniedException.php
@@ -110,7 +110,7 @@ class AccessDeniedException extends Exception
     const REASON_MANAGEMENT_REPORTS_RESOLVE_PICTURE_FOREIGN_NATURAL = 'Hlášení se vztahuje k obrázku, který není nahrán k žádné přírodnině ve vaší třídě';
     const REASON_MANAGEMENT_NATURALS_RENAME_NAME_TO_SHORT = 'Název přírodniny musí být alespoň 1 znak dlouhý';
     const REASON_MANAGEMENT_NATURALS_RENAME_NAME_TO_LONG = 'Název přírodniny nesmí být více než 31 znaků dlouhý';
-    const REASON_MANAGEMENT_NATURALS_RENAME_INVALID_CHARACTERS = 'Název přírodniny může obsahovat pouze písmena, číslice, mezeru a znaky . _ - + / * % ( ) \' \"';
+    const REASON_MANAGEMENT_NATURALS_RENAME_INVALID_CHARACTERS = 'Název přírodniny může obsahovat pouze písmena, číslice, mezeru a znaky . _ - + / * % ( ) \' "';
     const REASON_MANAGEMENT_NATURALS_RENAME_DUPLICATE_NAME = 'Tento název má již jiná přírodnina v této třídě';
     const REASON_MANAGEMENT_NATURALS_RENAME_FOREIGN_NATURAL = 'Tato přírodnina nepatří do spravované třídy';
     const REASON_MANAGEMENT_NATURALS_MERGE_FROM_FOREIGN_NATURAL = 'Přírodnina kterou se pokoušíte sloučit s jinou přírodninou nepatří do spravované třídy';

--- a/Models/Exceptions/AccessDeniedException.php
+++ b/Models/Exceptions/AccessDeniedException.php
@@ -108,6 +108,14 @@ class AccessDeniedException extends Exception
     const REASON_MANAGEMENT_NEW_GROUP_NAME_INVALID_CHARACTERS = 'Název poznávačky může obsahovat pouze písmena, číslice, mezeru a znaky . _ -';
     const REASON_MANAGEMENT_REPORTS_EDIT_PICTURE_ANOTHER_GROUP = 'Obrázek nelze přesunout k přírodnině, která není součástí té samé poznávačky';
     const REASON_MANAGEMENT_REPORTS_RESOLVE_PICTURE_FOREIGN_NATURAL = 'Hlášení se vztahuje k obrázku, který není nahrán k žádné přírodnině ve vaší třídě';
+    const REASON_MANAGEMENT_NATURALS_RENAME_NAME_TO_SHORT = 'Název přírodniny musí být alespoň 1 znak dlouhý';
+    const REASON_MANAGEMENT_NATURALS_RENAME_NAME_TO_LONG = 'Název přírodniny nesmí být více než 31 znaků dlouhý';
+    const REASON_MANAGEMENT_NATURALS_RENAME_INVALID_CHARACTERS = 'Název přírodniny může obsahovat pouze písmena, číslice, mezeru a znaky . _ - + / * % ( ) \' \"';
+    const REASON_MANAGEMENT_NATURALS_RENAME_DUPLICATE_NAME = 'Tento název má již jiná přírodnina v této třídě';
+    const REASON_MANAGEMENT_NATURALS_RENAME_FOREIGN_NATURAL = 'Tato přírodnina nepatří do spravované třídy';
+    const REASON_MANAGEMENT_NATURALS_MERGE_FROM_FOREIGN_NATURAL = 'Přírodnina kterou se pokoušíte sloučit s jinou přírodninou nepatří do spravované třídy';
+    const REASON_MANAGEMENT_NATURALS_MERGE_TO_FOREIGN_NATURAL = 'Přírodnina se kterou se pokoušíte sloučit jinou přírodniu nepatří do spravované třídy';
+    const REASON_MANAGEMENT_NATURALS_DELETE_FOREIGN_NATURAL = self::REASON_MANAGEMENT_NATURALS_RENAME_FOREIGN_NATURAL;
     const REASON_MANAGEMENT_EDIT_GROUP_DUPLICATE_GROUP = self::REASON_MANAGEMENT_NEW_GROUP_DUPLICATE_NAME;
     const REASON_MANAGEMENT_EDIT_GROUP_DUPLICATE_PART = 'Jedna nebo více částí se stejným nebo velmi podobným názvem je definována vícekrát'; //Zní to hloupě, ale k dosažení této hlášky je nutné modifikovat JavaScript
     const REASON_MANAGEMENT_EDIT_GROUP_DUPLICATE_NATURAL = 'V jedné nebo více částech se některá přírodnina vyskytuje vícekrát'; //Zní to hloupě, ale k dosažení této hlášky je nutné modifikovat JavaScript
@@ -119,9 +127,9 @@ class AccessDeniedException extends Exception
     const REASON_MANAGEMENT_EDIT_GROUP_PART_NAME_TOO_LONG = 'Název části nesmí být více než 31 znaků dlouhý';
     const REASON_MANAGEMENT_EDIT_GROUP_PART_NAME_INVALID_CHARACTERS = 'Název části může obsahovat pouze písmena, číslice, mezeru a znaky . _ -';
     const REASON_MANAGEMENT_EDIT_GROUP_PART_NAME_FORBIDDEN_URL = 'Název jedné z částí nelze z technických důvodů použít, pokuste se přidat nebo odebrat některé znaky';
-    const REASON_MANAGEMENT_EDIT_GROUP_NATURAL_NAME_TOO_SHORT = 'Název přírodniny musí být alespoň 1 znak dlouhý';
-    const REASON_MANAGEMENT_EDIT_GROUP_NATURAL_NAME_TOO_LONG = 'Název přírodniny nesmí být více než 31 znaků dlouhý';
-    const REASON_MANAGEMENT_EDIT_GROUP_NATURAL_NAME_INVALID_CHARACTERS = 'Název přírodniny může obsahovat pouze písmena, číslice, mezeru a znaky . _ - + / * % ( ) \' \"';
+    const REASON_MANAGEMENT_EDIT_GROUP_NATURAL_NAME_TOO_SHORT = self::REASON_MANAGEMENT_NATURALS_RENAME_NAME_TO_SHORT;
+    const REASON_MANAGEMENT_EDIT_GROUP_NATURAL_NAME_TOO_LONG = self::REASON_MANAGEMENT_NATURALS_RENAME_NAME_TO_LONG;
+    const REASON_MANAGEMENT_EDIT_GROUP_NATURAL_NAME_INVALID_CHARACTERS = self::REASON_MANAGEMENT_NATURALS_RENAME_INVALID_CHARACTERS;
     const REASON_ADMINISTRATION_ACCOUNT_UPDATE_INVALID_DATA = 'Jeden nebo více zadaných údajů není platných';
     const REASON_ADMINISTRATION_CLASS_UPDATE_INVALID_DATA = self::REASON_ADMINISTRATION_ACCOUNT_UPDATE_INVALID_DATA;
     const REASON_ADMINISTRATION_ACCOUNT_DELETION_ADMINISTRATOR = 'Tohoto uživatele nemůžete odstranit, protože spravuje některé třídy. Před opakováním akce změňte správce tříd, které tento uživatel spravuje a to skrze záložku "Správa tříd".';

--- a/Models/Processors/NaturalEditor.php
+++ b/Models/Processors/NaturalEditor.php
@@ -6,6 +6,8 @@ use Poznavacky\Models\DatabaseItems\ClassObject;
 use Poznavacky\Models\DatabaseItems\Natural;
 use Poznavacky\Models\Exceptions\AccessDeniedException;
 use Poznavacky\Models\Security\DataValidator;
+use \InvalidArgumentException;
+use \RangeException;
 
 /**
  * Model zpracovávající změny přírodnin odeslané ze stránky naturals

--- a/Models/Processors/NaturalEditor.php
+++ b/Models/Processors/NaturalEditor.php
@@ -73,7 +73,7 @@ class NaturalEditor
         return $natural->save();
     }
 
-    public function merge(Natural $from, Natural $to): bool
+    public function merge(Natural $from, Natural $to): array
     {
         if (!in_array($from->getId(), $this->idsOfNaturalsInClass))
         {

--- a/Models/Processors/NaturalEditor.php
+++ b/Models/Processors/NaturalEditor.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Poznavacky\Models\Processors;
+
+use Poznavacky\Models\DatabaseItems\ClassObject;
+use Poznavacky\Models\DatabaseItems\Natural;
+use Poznavacky\Models\Exceptions\AccessDeniedException;
+use Poznavacky\Models\Security\DataValidator;
+
+/**
+ * Model zpracovávající změny přírodnin odeslané ze stránky naturals
+ * Třída slouží spíše jako mezičlánek provádějící veškerá ověření
+ * @author Jan Štěch
+ */
+class NaturalEditor
+{
+    private $class;
+    private $idsOfNaturalsInClass;
+
+    /**
+     * Konstruktor modelu nastavující objekt třídy, v níž je dovoleno upravovat přírodniny a získávající seznam jejich ID
+     * @param ClassObject $class Objekt třídy, která má být pomocí tohoto objektu spravována
+     */
+    public function __construct(ClassObject $class)
+    {
+        $this->class = $class;
+        $this->idsOfNaturalsInClass = array_map(function($item) { return $item->getId(); }, $class->getNaturals());
+    }
+
+    public function rename(Natural $natural, string $newName): bool
+    {
+        //Zkontroluj, zda je název přírodniny platný
+        $validator = new DataValidator();
+        try
+        {
+            $validator->checkLength($newName, DataValidator::NATURAL_NAME_MIN_LENGTH, DataValidator::NATURAL_NAME_MAX_LENGTH, DataValidator::TYPE_NATURAL_NAME);
+            $validator->checkCharacters($newName, DataValidator::NATURAL_NAME_ALLOWED_CHARS, DataValidator::TYPE_NATURAL_NAME);
+        }
+        catch (RangeException $e)
+        {
+            switch ($e->getMessage())
+            {
+                case 'short':
+                    throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_NATURALS_RENAME_NAME_TO_SHORT, null, $e);
+                    break;
+                case 'long':
+                    throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_NATURALS_RENAME_NAME_TO_LONG, null, $e);
+                    break;
+            }
+        }
+        catch (InvalidArgumentException $e)
+        {
+            throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_NATURALS_RENAME_INVALID_CHARACTERS, null, $e);
+        }
+
+        try
+        {
+            $validator->checkUniqueness($newName, DataValidator::TYPE_NATURAL_NAME, $this->class);
+        }
+        catch (InvalidArgumentException $e)
+        {
+            throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_NATURALS_RENAME_DUPLICATE_NAME);
+        }
+
+        if (!in_array($natural->getId(), $this->idsOfNaturalsInClass))
+        {
+            throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_NATURALS_RENAME_FOREIGN_NATURAL);
+        }
+
+        $natural->rename($newName);
+        return $natural->save();
+    }
+
+    public function merge(Natural $from, Natural $to): bool
+    {
+        if (!in_array($from->getId(), $this->idsOfNaturalsInClass))
+        {
+            throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_NATURALS_MERGE_FROM_FOREIGN_NATURAL);
+        }
+        if (!in_array($to->getId(), $this->idsOfNaturalsInClass))
+        {
+            throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_NATURALS_MERGE_TO_FOREIGN_NATURAL);
+        }
+
+        return $from->merge($to);
+    }
+
+    public function delete(Natural $natural): bool
+    {
+        if (!in_array($natural->getId(), $this->idsOfNaturalsInClass))
+        {
+            throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_NATURALS_DELETE_FOREIGN_NATURAL);
+        }
+
+        return $natural->delete();
+    }
+}

--- a/Models/Security/DataValidator.php
+++ b/Models/Security/DataValidator.php
@@ -4,6 +4,7 @@ namespace Poznavacky\Models\Security;
 use Poznavacky\Models\DatabaseItems\ClassNameChangeRequest;
 use Poznavacky\Models\DatabaseItems\ClassObject;
 use Poznavacky\Models\DatabaseItems\Group;
+use Poznavacky\Models\DatabaseItems\Natural;
 use Poznavacky\Models\DatabaseItems\Part;
 use Poznavacky\Models\DatabaseItems\User;
 use Poznavacky\Models\DatabaseItems\UserNameChangeRequest;

--- a/Models/Security/DataValidator.php
+++ b/Models/Security/DataValidator.php
@@ -38,9 +38,9 @@ class DataValidator
     public const USER_EMAIL_MAX_LENGTH = 255;
     public const CLASS_NAME_MIN_LENGTH = 5;
     public const CLASS_NAME_MAX_LENGTH = 31;
+    //Při změně následujících konstant je nutné změnit hodnoty i v souborech edit.js, edit.phtml a naturals.js
     public const GROUP_NAME_MIN_LENGTH = 3;
     public const GROUP_NAME_MAX_LENGTH = 31;
-    //Při změně následujících čtyř konstant je nutné změnit hodnoty i v souborech edit.js a edit.phtml
     public const PART_NAME_MIN_LENGTH = 1;
     public const PART_NAME_MAX_LENGTH = 31;
     public const NATURAL_NAME_MIN_LENGTH = 1;
@@ -54,7 +54,7 @@ class DataValidator
     public const PART_NAME_ALLOWED_CHARS = '0123456789aábcčdďeěéfghiíjklmnňoópqrřsštťuůúvwxyýzžAÁBCČDĎEĚÉFGHIÍJKLMNŇOÓPQRŘSŠTŤUŮÚVWXYZŽ _.-';  //Při změně je nutné změnit hodnoty i v souboru edit.js
     public const NATURAL_NAME_ALLOWED_CHARS = '0123456789aábcčdďeěéfghiíjklmnňoópqrřsštťuůúvwxyýzžAÁBCČDĎEĚÉFGHIÍJKLMNŇOÓPQRŘSŠTŤUŮÚVWXYZŽ _.-+/*%()\'\"';  //Při změně je nutné změnit hodnoty i v souboru edit.js
 
-    public const URL_ALLOWED_CHARS = '0123456789abcdefghijklmnopqrstuvwxyz';
+    public const URL_ALLOWED_CHARS = '0123456789abcdefghijklmnopqrstuvwxyz'; //(plus znak -)
 
     public const CLASS_RESERVED_URLS = array('account-settings', 'enter-class-code');
     public const GROUP_RESERVED_URLS = array('leave', 'manage');
@@ -164,6 +164,18 @@ class DataValidator
                 }
                 
                 $result = Db::fetchQuery('SELECT COUNT(*) AS "cnt" FROM '.Part::TABLE_NAME.' WHERE '.Part::COLUMN_DICTIONARY['url'].' = ? AND '.Part::COLUMN_DICTIONARY['group'].' = ? LIMIT 1', array($subject, $parentFolder->getId()), false);
+                if ($result['cnt'] > 0)
+                {
+                    throw new InvalidArgumentException(null, $stringType);
+                }
+                break;
+            case self::TYPE_NATURAL_NAME:
+                if ($parentFolder === null)
+                {
+                    throw new BadMethodCallException('Parent object must be specified for this check');
+                }
+
+                $result = Db::fetchQuery('SELECT COUNT(*) AS "cnt" FROM '.Natural::TABLE_NAME.' WHERE '.Natural::COLUMN_DICTIONARY['name'].' = ? AND '.Natural::COLUMN_DICTIONARY['class'].' = ? LIMIT 1', array($subject, $parentFolder->getId()), false);
                 if ($result['cnt'] > 0)
                 {
                     throw new InvalidArgumentException(null, $stringType);

--- a/Views/manage.phtml
+++ b/Views/manage.phtml
@@ -59,10 +59,10 @@
 	</section>
 	<section class="class-buttons-section">
 		<div id="manage-buttons">
-			<button class="btn border-btn non-transparent black" id="members-management-button" onclick='window.location.href=window.location.href+"/members";'<?php if ($classStatus === Poznavacky\Models\DatabaseItems\ClassObject::CLASS_STATUS_PUBLIC) : ?>style="display:none"<?php endif ?>>Spravovat členy třídy
-			</button>
-			<button class="btn border-btn non-transparent black" onclick='window.location.href=window.location.href+"/tests";'>Spravovat poznávačky</button>
-		</div>
+			<a class="btn border-btn non-transparent black" id="members-management-button" href="<?= $baseUrl ?>/members" <?php if ($classStatus === Poznavacky\Models\DatabaseItems\ClassObject::CLASS_STATUS_PUBLIC) : ?>style="display:none"<?php endif ?>>Spravovat členy třídy</a>
+			<a class="btn border-btn non-transparent black" href="<?= $baseUrl ?>/tests">Spravovat poznávačky</a>
+		    <a class="btn border-btn non-transparent black" href="<?= $baseUrl ?>/naturals">Spravovat přírodniny</a>
+        </div>
 		<button class="btn border-btn non-transparent black" id="delete-class-button">Zrušit třídu</button>
 		<div id="delete-class" style="display: none;">
 			<h3>Zrušení účtu</h3>

--- a/Views/menuPartsTable.phtml
+++ b/Views/menuPartsTable.phtml
@@ -16,14 +16,14 @@
 				<span class="tiles">obrázků: </span>
 				<span><?= $tableRow[2] ?></span>
 			</span>
-            <?php if ($tableRow[2] > 0) : ?>
+            <?php if ($tableRow[1] > 0) : ?>
             <div class="buttons">
                 <a href="<?= $tableRow['rowLink'].'/add-pictures' ?>" class="btn transparent black border-btn">Přidat obrázky</a>
                 <a href="<?= $tableRow['rowLink'].'/learn' ?>" class="btn transparent black border-btn">Učit se</a>
                 <a href="<?= $tableRow['rowLink'].'/test' ?>" class="btn transparent black border-btn">Vyzkoušet se</a>
             </div>
             <?php endif ?>
-            <?php if ($tableRow[2] === '0') : ?>
+            <?php if ($tableRow[1] === '0') : ?>
                 <div>
                     <span>Pro používání této části do ní musí být nejprve přidány přírodniny</span>
                 </div>

--- a/Views/naturals.phtml
+++ b/Views/naturals.phtml
@@ -6,6 +6,7 @@
     jí odeberete i ze všech poznávaček a jejich částí</p>
     <p>Přejmenováním přírodniny dojde k aktualizaci názvu ve všech poznávačkách,
     ve kterých se přírodnina vyskytuje.</p>
+    <p>Nové přírodniny jsou přidávány automaticky při tvorbě nebo úpravě poznávaček.</p>
     <p>Přírodniny jsou seřazeny podle data přidání. Pro rychlé nalezení určité
     přírodniny můžete použít kombinaci kláves <kbd>Ctrl</kbd>+<kbd>F</kbd></p>
 
@@ -18,16 +19,33 @@
         </tr>
         <?php foreach ($naturals as $natural) : ?>
         <tr data-natural-id="<?= $natural->getId() ?>">
-            <td><?= $natural->getName() ?></td>
+            <td>
+                <div class="natural-name-box">
+                    <span class="natural-name"><?= $natural->getName() ?></span>
+                </div>
+                <div class="natural-name-input-box" style="display:none;">
+                    <input type="text" maxlength="31" class="text-field natural-name-input" value="<?= $natural->getName() ?>"/>
+                </div>
+            </td>
             <td><?= $natural->getUsesCount() ?></td>
             <td><?= $natural->getPicturesCount() ?></td>
             <td>
-                <button title="Přejmenovat" class="rename-natural btn icon">
-                    <img src='images/pencil.svg'/>
-                </button>
-                <button title="Odebrat" class="remove-natural btn icon">
-                    <img src='images/cross.svg'/>
-                </button>
+                <div class="normal-buttons">
+                    <button title="Přejmenovat" class="rename-natural btn icon">
+                        <img src='images/pencil.svg'/>
+                    </button>
+                    <button title="Odebrat" class="remove-natural btn icon">
+                        <img src='images/cross.svg'/>
+                    </button>
+                </div>
+                <div class="rename-buttons" style="display:none;">
+                    <button class="rename-confirm btn icon">
+                        <img src='images/tick.svg'/>
+                    </button>
+                    <button class="rename-cancel btn icon">
+                        <img src='images/crossRed.svg'/>
+                    </button>
+                </div>
             </td>
         </tr>
         <?php endforeach ?>

--- a/Views/naturals.phtml
+++ b/Views/naturals.phtml
@@ -1,0 +1,35 @@
+<div id='naturals-wrapper'>
+    <p>Na této stránce můžete spravovat přírodniny, které ve vaší třídě existují.</p>
+    <p>Nahrané obrázky jsou pevně svázány s jednotlivými přírodninami. Odstraněním
+    přírodniny dojde i k odstranění všech obrázků, které k ní byly přidány</p>
+    <p>Odstraněním přírodniny, která je přiřazená do alespoň jedné poznávačky
+    jí odeberete i ze všech poznávaček a jejich částí</p>
+    <p>Přejmenováním přírodniny dojde k aktualizaci názvu ve všech poznávačkách,
+    ve kterých se přírodnina vyskytuje.</p>
+    <p>Přírodniny jsou seřazeny podle data přidání. Pro rychlé nalezení určité
+    přírodniny můžete použít kombinaci kláves <kbd>Ctrl</kbd>+<kbd>F</kbd></p>
+
+    <table>
+        <tr>
+            <th>Název přírodniny</th>
+            <th>Místa výskytu</th>
+            <th>Počet obrázků</th>
+            <th>Akce</th>
+        </tr>
+        <?php foreach ($naturals as $natural) : ?>
+        <tr data-natural-id="<?= $natural->getId() ?>">
+            <td><?= $natural->getName() ?></td>
+            <td><?= $natural->getUsesCount() ?></td>
+            <td><?= $natural->getPicturesCount() ?></td>
+            <td>
+                <button title="Přejmenovat" class="rename-natural btn icon">
+                    <img src='images/pencil.svg'/>
+                </button>
+                <button title="Odebrat" class="remove-natural btn icon">
+                    <img src='images/cross.svg'/>
+                </button>
+            </td>
+        </tr>
+        <?php endforeach ?>
+    </table>
+</div>

--- a/docs/COOKIES_INFO.md
+++ b/docs/COOKIES_INFO.md
@@ -29,4 +29,4 @@ Pokud chcete z jakéhokoli důvodu všechny uložené soubory cookie odstranit, 
 
 V běžných webových prohlížečích pro počítače (Microsoft Edge, Google Chrome, Mozila Firefox) naleznete tuto možnost po levé straně adresního řádku. Po kliknutí na ikonku zámku signalizující zabezpečené připojení klikněte na `Soubory cookie` (Microsoft Edge, Google Chrome) nebo `Vymazat cookies a data stránky` (Mozila Firefox), následně vyberte doménu `poznavacky.com` a klikněte na `Odebrat`, případně `Odstranit`.
 
-Na mobilních prohlížečích naleznete tuto možnost na podobném místě, avšak obvykle v menu "Nastavení webu". V případě problémů nás můžete kontaktovat na e-mailové adrese _poznavacky@email.com_.
+Na mobilních prohlížečích naleznete tuto možnost na podobném místě, avšak obvykle v menu "Nastavení webu". V případě problémů nás můžete kontaktovat na e-mailové adrese *poznavacky@email.com*.

--- a/js/edit.js
+++ b/js/edit.js
@@ -146,7 +146,7 @@ function renameConfirm(event, type)
 	//let maxChars = (type === "group") ? 31 : (type === "part") ? 31 : 31;
 	let maxChars = 31; //V případě, že by horní limit všech typů stringů neměl být stejný, odkomentovat předchozí řádku a tuto zakomentovat
 	//Při změně povolených znaků nezapomenout aktualizovat i znaky nahrazované "-" ve funkci generateUrl()
-	let allowedChars = (type === "group") ? "0123456789aábcčdďeěéfghiíjklmnňoópqrřsštťuůúvwxyýzžAÁBCČDĎEĚÉFGHIÍJKLMNŇOÓPQRŘSŠTŤUŮÚVWXYZŽ _.-" : (type === "part") ? "0123456789aábcčdďeěéfghiíjklmnňoópqrřsštťuůúvwxyýzžAÁBCČDĎEĚÉFGHIÍJKLMNŇOÓPQRŘSŠTŤUŮÚVWXYZŽ _.-" : "\"0123456789aábcčdďeěéfghiíjklmnňoópqrřsštťuůúvwxyýzžAÁBCČDĎEĚÉFGHIÍJKLMNŇOÓPQRŘSŠTŤUŮÚVWXYZŽ _.+/*%()\'\"-"; //- musí být z nějakého důvodu až na konci"
+	let allowedChars = (type === "group") ? "0123456789aábcčdďeěéfghiíjklmnňoópqrřsštťuůúvwxyýzžAÁBCČDĎEĚÉFGHIÍJKLMNŇOÓPQRŘSŠTŤUŮÚVWXYZŽ _.-" : (type === "part") ? "0123456789aábcčdďeěéfghiíjklmnňoópqrřsštťuůúvwxyýzžAÁBCČDĎEĚÉFGHIÍJKLMNŇOÓPQRŘSŠTŤUŮÚVWXYZŽ _.-" : "0123456789aábcčdďeěéfghiíjklmnňoópqrřsštťuůúvwxyýzžAÁBCČDĎEĚÉFGHIÍJKLMNŇOÓPQRŘSŠTŤUŮÚVWXYZŽ _.+/*%()\'\"-"; //- musí být z nějakého důvodu až na konci"
 	let allowedSpecialChars = (type === "group") ? ". _ -" : (type === "part") ? ". _ -" : "_ . - + / * % ( ) \' \"" //Pouze pro použití v chybových hláškách
 
 	let $nameInputBox = $(".natural-name-input-box, .part-name-input-box, .group-name-input-box");

--- a/js/members.js
+++ b/js/members.js
@@ -1,5 +1,3 @@
-var deletedTableRow;    //Ukládá řádek tabulky členů, který je odstraňován
-
 //Nastavení URL pro AJAX požadavky
 let ajaxUrl = window.location.href;
 if (ajaxUrl.endsWith('/')) { ajaxUrl = ajaxUrl.slice(0, -1); } //Odstraň trailing slash (pokud je přítomen)
@@ -36,7 +34,7 @@ function kickUserConfirm(event)
 {
 	let memberId = $(event.target).closest(".members-data-item").attr("data-member-id");
 
-    deletedTableRow = $(event.target).closest(".members-data-item").remove();
+    let $deletedTableRow = $(event.target).closest(".members-data-item");
     $.post(ajaxUrl,
 		{
     		action: 'kick member',
@@ -56,9 +54,8 @@ function kickUserConfirm(event)
 						//newMessage(message, "success")
 
 						//odebrání uživatele z DOM
-						deletedTableRow.remove();
+						$deletedTableRow.remove();
 					}
-					deletedTableRow = undefined;
 				}
 			);
 		},

--- a/js/naturals.js
+++ b/js/naturals.js
@@ -1,0 +1,54 @@
+//vše, co se děje po načtení stránky
+$(function() {
+
+    //event listenery tlačítek
+    $(".rename-natural").click(function(event) {rename(event)})
+    $(".rename-confirm").click(function(event) {renameConfirm(event)})
+    $(".rename-cancel").click(function(event) {renameCancel(event)})
+    $(".remove-natural").click(function(event) {remove(event)})
+})
+
+/**
+ * Funkce zobrazující vstupní pole pro přejmenování přírodniny
+ */
+function rename(event)
+{
+    console.log("rename");
+    $(event.target).closest('tr').find('.normal-buttons').hide();
+    $(event.target).closest('tr').find('.natural-name-box').hide();
+    $(event.target).closest('tr').find('.rename-buttons').show();
+    $(event.target).closest('tr').find('.natural-name-input-box').show();
+
+    $(event.target).closest('tr').find('.natural-name-input').select();
+}
+
+/**
+ * Funkce potvrzující přejmenování přírodniny, kontrolující údaje a odesílající AJAX požadavek na server
+ */
+function renameConfirm(event)
+{
+    //TODO
+}
+
+/**
+ * Funkce skrývající vstupní pole pro přejmenování přírodniny a obnovující ho do původního stavu
+ */
+function renameCancel(event)
+{
+    $(event.target).closest('tr').find('.rename-buttons').hide();
+    $(event.target).closest('tr').find('.natural-name-input-box').hide();
+    $(event.target).closest('tr').find('.normal-buttons').show();
+    $(event.target).closest('tr').find('.natural-name-box').show();
+
+    $(event.target).closest('tr').find('.natural-name-input').val($(event.target).closest('tr').find('.natural-name').text());
+}
+
+/**
+ * Funkce odebírající přírodninu a odesílající AJAX požadavek na její odstranění na server
+ */
+function remove(event)
+{
+    console.log("remove");
+    //TODO
+}
+

--- a/js/naturals.js
+++ b/js/naturals.js
@@ -8,8 +8,9 @@ $(function() {
 
     //event listenery tlačítek
     $(".rename-natural").click(function(event) {rename(event)})
+    $(".natural-name-input").keyup(function(event) { if (event.keyCode === 13) renameConfirm(event) })
     $(".rename-confirm").click(function(event) {renameConfirm(event)})
-    $(".rename-cancel").click(function(event) {renameCancel(event)})
+    $(".rename-cancel").click(function(event) {renameCancel(event.target)})
     $(".remove-natural").click(function(event) {remove(event)})
 })
 
@@ -19,12 +20,12 @@ $(function() {
 function rename(event)
 {
     console.log("rename");
-    $(event.target).closest('tr').find('.normal-buttons').hide();
-    $(event.target).closest('tr').find('.natural-name-box').hide();
-    $(event.target).closest('tr').find('.rename-buttons').show();
-    $(event.target).closest('tr').find('.natural-name-input-box').show();
+    $(event.target).closest('tr[data-natural-id]').find('.normal-buttons').hide();
+    $(event.target).closest('tr[data-natural-id]').find('.natural-name-box').hide();
+    $(event.target).closest('tr[data-natural-id]').find('.rename-buttons').show();
+    $(event.target).closest('tr[data-natural-id]').find('.natural-name-input-box').show();
 
-    $(event.target).closest('tr').find('.natural-name-input').select();
+    $(event.target).closest('tr[data-natural-id]').find('.natural-name-input').select();
 }
 
 /**
@@ -32,20 +33,143 @@ function rename(event)
  */
 function renameConfirm(event)
 {
-    //TODO
+    let minChars = 1;
+    let maxChars = 31;
+    let allowedChars = "0123456789aábcčdďeěéfghiíjklmnňoópqrřsštťuůúvwxyýzžAÁBCČDĎEĚÉFGHIÍJKLMNŇOÓPQRŘSŠTŤUŮÚVWXYZŽ _.+/*%()\'\"-"; //- musí být z nějakého důvodu až na konci"
+
+    if ($(event.target).prop("tagName") !== "INPUT")
+    {
+        //Potvrzení tlačítkem (kliknuto na obrázek, který jej vyplňuje)
+        newName = $(event.target).closest('tr[data-natural-id]').find(".natural-name-input").val();
+        oldName = $(event.target).closest('tr[data-natural-id]').find(".natural-name").text();
+    }
+    else
+    {
+        //Potvrzení Enterem
+        newName = $(event.target).val();
+        oldName = $(event.target).closest('td').find(".natural-name").text();
+    }
+
+    if (newName.toUpperCase() !== oldName.toUpperCase()) //Prováděj kontroly pouze pokud se nejedná o změny ve velikosti písmen
+    {
+        //Kontrola délky
+        if (newName === undefined || !(newName.length >= minChars && newName.length <= maxChars))
+        {
+            alert("Název přírodniny musí mít 1 až 31 znaků");
+            return;
+        }
+
+        //Kontrola znaků
+        let re = new RegExp("[^" + allowedChars + "]", 'g');
+        if (newName.match(re) !== null)
+        {
+            alert("Název přírodniny může obsahovat pouze písmena, číslice, mezeru a znaky _ . - + / * % ( ) \' \"");
+            return;
+        }
+
+        //Kontrola unikátnosti
+        let presentNaturals;
+        //Získej seznam přidaných přírodnin - kód inspirovaný odpovědí na StackOverflow: https://stackoverflow.com/a/3496338/14011077
+        presentNaturals = $("#naturals-wrapper").find(".natural-name").map(function() {return $(this).text().toUpperCase(); }).get();
+
+        if (presentNaturals.includes(newName.toUpperCase()))
+        {
+            let merge = confirm("Přírodnina s tímto názvem již existuje\nChcete tyto dvě přírodniny sloučit? Všechny obrázky zvolené přírodniny a hlášení k nim se vztahující budou přesunuty k existující přírodnině s tímto názvem a zvolená přírodnina bude odstraněna.\nTato akce je nevratná.");
+            if (merge)
+            {
+                let fromNaturalId = $(event.target).closest('tr[data-natural-id]').attr("data-natural-id");
+                let toNaturalId = $("#naturals-wrapper").find("tr[data-natural-id]:eq(" + presentNaturals.indexOf(newName.toUpperCase()) + ")").attr("data-natural-id");
+                console.log(fromNaturalId + " → " + toNaturalId);
+                mergeNaturals(fromNaturalId, toNaturalId);
+            }
+            return;
+        }
+    }
+
+    //Kontrola informací OK
+
+    let $targetRow = $(event.target).closest('tr[data-natural-id]');
+    $.post(ajaxUrl,
+        {
+            action: 'rename',
+            naturalId: $(event.target).closest('tr[data-natural-id]').attr('data-natural-id'),
+            newName: newName
+        },
+        function (response, status)
+        {
+            ajaxCallback(response, status,
+                function (messageType, message, data)
+                {
+                    if (messageType === "error")
+                    {
+                        newMessage(message, "error");
+                    }
+                    else if (messageType === "success")
+                    {
+                        //newMessage(message, "success")
+
+                        //Nastavení nového názvu přírodniny a reset DOM
+                        $targetRow.find(".natural-name").text($targetRow.find(".natural-name-input").val())
+
+                        renameCancel(event.target)
+                    }
+                }
+            );
+        },
+        "json"
+    );
 }
 
 /**
  * Funkce skrývající vstupní pole pro přejmenování přírodniny a obnovující ho do původního stavu
+ * @param clickedButton HTML element tlačítka, na které bylo kliknuto
  */
-function renameCancel(event)
+function renameCancel(clickedButton)
 {
-    $(event.target).closest('tr').find('.rename-buttons').hide();
-    $(event.target).closest('tr').find('.natural-name-input-box').hide();
-    $(event.target).closest('tr').find('.normal-buttons').show();
-    $(event.target).closest('tr').find('.natural-name-box').show();
+    $(clickedButton).closest('tr[data-natural-id]').find('.rename-buttons').hide();
+    $(clickedButton).closest('tr[data-natural-id]').find('.natural-name-input-box').hide();
+    $(clickedButton).closest('tr[data-natural-id]').find('.normal-buttons').show();
+    $(clickedButton).closest('tr[data-natural-id]').find('.natural-name-box').show();
 
-    $(event.target).closest('tr').find('.natural-name-input').val($(event.target).closest('tr').find('.natural-name').text());
+    $(clickedButton).closest('tr[data-natural-id]').find('.natural-name-input').val($(clickedButton).closest('tr').find('.natural-name').text());
+}
+
+/**
+ * Funkce slučující dvě přírodniny (odstraňuje vybranou a převádí její obrázky k nové)
+ * Toto je stvrzno odesláním AJAX požadavku na provedení změn v databázi
+ * @param fromNaturalId ID přírodniny, jejíž obrázky mají být převedeny a přírodnina odstraněna
+ * @param toNaturalId ID přírodniny, ke které mají být obrázky převedeny
+ */
+function mergeNaturals(fromNaturalId, toNaturalId)
+{
+    let deletedTableRow = $("[data-natural-id=" + fromNaturalId + "]");
+    $.post(ajaxUrl,
+        {
+            action: 'merge',
+            fromNaturalId: fromNaturalId,
+            toNaturalId: toNaturalId
+        },
+        function (response, status)
+        {
+            ajaxCallback(response, status,
+                function (messageType, message, data)
+                {
+                    if (messageType === "error")
+                    {
+                        newMessage(message, "error");
+                    }
+                    else if (messageType === "success")
+                    {
+                        //newMessage(message, "success")
+
+                        //odebrání sloučené přírodniny z DOM
+                        deletedTableRow.remove();
+                    }
+                }
+            );
+        },
+        "json"
+    );
 }
 
 /**
@@ -53,13 +177,13 @@ function renameCancel(event)
  */
 function remove(event)
 {
-    if (!confirm('Skutečně chcete odstranit přírodninu "'+$(event.target).closest('tr').find('.natural-name').text()+'" a všechny obrázky k ní přidané?\nTato akce je nevratná!')){ return }
+    if (!confirm('Skutečně chcete odstranit přírodninu "'+$(event.target).closest('tr[data-natural-id]').find('.natural-name').text()+'" a všechny obrázky k ní přidané?\nTato akce je nevratná!')){ return }
 
     let deletedTableRow = $(event.target).closest('tr');
     $.post(ajaxUrl,
         {
             action: 'delete',
-            naturalId: $(event.target).closest('tr').attr('data-natural-id')
+            naturalId: $(event.target).closest('tr[data-natural-id]').attr('data-natural-id')
         },
         function (response, status)
         {

--- a/js/naturals.js
+++ b/js/naturals.js
@@ -19,7 +19,6 @@ $(function() {
  */
 function rename(event)
 {
-    console.log("rename");
     $(event.target).closest('tr[data-natural-id]').find('.normal-buttons').hide();
     $(event.target).closest('tr[data-natural-id]').find('.natural-name-box').hide();
     $(event.target).closest('tr[data-natural-id]').find('.rename-buttons').show();
@@ -79,7 +78,6 @@ function renameConfirm(event)
             {
                 let fromNaturalId = $(event.target).closest('tr[data-natural-id]').attr("data-natural-id");
                 let toNaturalId = $("#naturals-wrapper").find("tr[data-natural-id]:eq(" + presentNaturals.indexOf(newName.toUpperCase()) + ")").attr("data-natural-id");
-                console.log(fromNaturalId + " → " + toNaturalId);
                 mergeNaturals(fromNaturalId, toNaturalId);
             }
             return;

--- a/js/naturals.js
+++ b/js/naturals.js
@@ -163,8 +163,8 @@ function mergeNaturals(fromNaturalId, toNaturalId)
 
                         //odebrání sloučené přírodniny z DOM a přičtení jejích statistik k přírodnině, do které byla sloučena
                         $deletedTableRow.remove();
-                        $mergedTableRow.find('td:eq(1)').text($mergedTableRow.find('td:eq(1)').text() + data.newUsesCount);
-                        $mergedTableRow.find('td:eq(2)').text($mergedTableRow.find('td:eq(2)').text() + data.newPictureCount);
+                        $mergedTableRow.find('td:eq(1)').text(Number($mergedTableRow.find('td:eq(1)').text()) + data.newUsesCount);
+                        $mergedTableRow.find('td:eq(2)').text(Number($mergedTableRow.find('td:eq(2)').text()) + data.newPicturesCount);
                     }
                 }
             );

--- a/js/naturals.js
+++ b/js/naturals.js
@@ -1,4 +1,9 @@
-//vše, co se děje po načtení stránky
+//Nastavení URL pro AJAX požadavky
+let ajaxUrl = window.location.href;
+if (ajaxUrl.endsWith('/')) { ajaxUrl = ajaxUrl.slice(0, -1); } //Odstraň trailing slash (pokud je přítomen)
+ajaxUrl = ajaxUrl.replace('/naturals', '/update-naturals'); //Nahraď neAJAX akci AJAX akcí
+
+// vše, co se děje po načtení stránky
 $(function() {
 
     //event listenery tlačítek
@@ -48,7 +53,34 @@ function renameCancel(event)
  */
 function remove(event)
 {
-    console.log("remove");
-    //TODO
+    if (!confirm('Skutečně chcete odstranit přírodninu "'+$(event.target).closest('tr').find('.natural-name').text()+'" a všechny obrázky k ní přidané?\nTato akce je nevratná!')){ return }
+
+    let deletedTableRow = $(event.target).closest('tr');
+    $.post(ajaxUrl,
+        {
+            action: 'delete',
+            naturalId: $(event.target).closest('tr').attr('data-natural-id')
+        },
+        function (response, status)
+        {
+            ajaxCallback(response, status,
+                function (messageType, message, data)
+                {
+                    if (messageType === "error")
+                    {
+                        newMessage(message, "error");
+                    }
+                    else if (messageType === "success")
+                    {
+                        //newMessage(message, "success")
+
+                        //odebrání přírodniny z DOM
+                        deletedTableRow.remove();
+                    }
+                }
+            );
+        },
+        "json"
+    );
 }
 

--- a/js/naturals.js
+++ b/js/naturals.js
@@ -140,7 +140,8 @@ function renameCancel(clickedButton)
  */
 function mergeNaturals(fromNaturalId, toNaturalId)
 {
-    let deletedTableRow = $("[data-natural-id=" + fromNaturalId + "]");
+    let $deletedTableRow = $("[data-natural-id=" + fromNaturalId + "]");
+    let $mergedTableRow = $("[data-natural-id=" + toNaturalId + "]");
     $.post(ajaxUrl,
         {
             action: 'merge',
@@ -160,8 +161,10 @@ function mergeNaturals(fromNaturalId, toNaturalId)
                     {
                         //newMessage(message, "success")
 
-                        //odebrání sloučené přírodniny z DOM
-                        deletedTableRow.remove();
+                        //odebrání sloučené přírodniny z DOM a přičtení jejích statistik k přírodnině, do které byla sloučena
+                        $deletedTableRow.remove();
+                        $mergedTableRow.find('td:eq(1)').text($mergedTableRow.find('td:eq(1)').text() + data.newUsesCount);
+                        $mergedTableRow.find('td:eq(2)').text($mergedTableRow.find('td:eq(2)').text() + data.newPictureCount);
                     }
                 }
             );

--- a/js/tests.js
+++ b/js/tests.js
@@ -1,10 +1,11 @@
 var deletedTableRow;    //Ukládá řádek tabulky potnávaček, který je odstraňován
+var ajaxUrl;
 
 //vše, co se děje po načtení stránky
 $(function() {
   
   //Nastavení URL pro AJAX požadavky
-  let ajaxUrl = window.location.href;
+  ajaxUrl = window.location.href;
   if (ajaxUrl.endsWith('/')) { ajaxUrl = ajaxUrl.slice(0, -1); } //Odstraň trailing slash (pokud je přítomen)
   ajaxUrl = ajaxUrl.replace('/manage/tests', '/class-update'); //Nahraď neAJAX akci AJAX akcí
   


### PR DESCRIPTION
Stránka pro správu přírodnin (včetně nepřiřazených je přidána).
Stránka umožňuje přejmenovávat (a tím i slučovat) nebo odstraňovat přírodniny.
Dále je opraveno několik dříve neodhalených bugů.

Databáze by neměla vyžadovat žádné změny.