### PR TITLE
Aktualizace URL adres na tento GitHub repozitář

### DIFF
--- a/Models/ChangelogManager.php
+++ b/Models/ChangelogManager.php
@@ -12,7 +12,7 @@ use Poznavacky\Models\Statics\UserManager;
 class ChangelogManager
 {
     public const LATEST_VERSION = '4.0';
-    private const GITHUB_API_RELEASES_URL = 'https://api.github.com/repos/HonzaSTECH/Poznavacky/releases/';
+    private const GITHUB_API_RELEASES_URL = 'https://api.github.com/repos/ShadyMedic/Poznavacky/releases/';
     private const RELEASE_IDS = array(
         '4.0' => 41734877,
         '3.2' => 22530404,

--- a/Models/GitHubFileFetcher.php
+++ b/Models/GitHubFileFetcher.php
@@ -10,7 +10,7 @@ use \UnexpectedValueException;
  */
 class GitHubFileFetcher
 {
-    private const GITHUB_API_REPOSITORY_URL = 'https://api.github.com/repos/HonzaSTECH/Poznavacky/contents/';
+    private const GITHUB_API_REPOSITORY_URL = 'https://api.github.com/repos/ShadyMedic/Poznavacky/contents/';
     private const TERMS_OF_SERVICE_PATH = 'docs/TERMS_OF_SERVICE.md';
     private const PRIVACY_POLICY_PATH = 'docs/PRIVACY_POLICY.md';
     private const COOKIES_INFO_PATH = 'docs/COOKIES_INFO.md';


### PR DESCRIPTION
V důsledku změny jména mého profilu nefungovalo načítání changelogů a právních informací.
Aktualizací URL adres ve dvou souborech komunikujících s GitHub API byl problém vyřešen.