### PR TITLE
Oprava kritického bugu umožňující registraci více účtů se stejným jménem

### DIFF
--- a/Models/Security/DataValidator.php
+++ b/Models/Security/DataValidator.php
@@ -169,7 +169,7 @@ class DataValidator
                                          UserNameChangeRequest::COLUMN_DICTIONARY['newName'].') FROM '.
                                          UserNameChangeRequest::TABLE_NAME.' WHERE UPPER('.
                                          UserNameChangeRequest::COLUMN_DICTIONARY['newName'].') = ?) AS tmp',
-                    array(strtoupper($subject), strtoupper($subject)), false);
+                    array(mb_strtoupper($subject), mb_strtoupper($subject)), false);
                 if ($result['cnt'] > 0) {
                     throw new InvalidArgumentException(null, $stringType);
                 }


### PR DESCRIPTION
Kontrola unikátnosti nefungovala pro jména obsahující diakritiku.
V databázi například máme dva účty se jménem "Karolína".
Teď jdu nějak zkusit vyřešit tu databázi, ale nová duplicitní jména by se již neměla objevovat.