### PR TITLE
Přidání ID releasů do ChangelogManager.php

### DIFF
--- a/Models/ChangelogManager.php
+++ b/Models/ChangelogManager.php
@@ -11,9 +11,11 @@ use Poznavacky\Models\Statics\UserManager;
  */
 class ChangelogManager
 {
-    public const LATEST_VERSION = '4.0';
+    public const LATEST_VERSION = '4.1.1';
     private const GITHUB_API_RELEASES_URL = 'https://api.github.com/repos/ShadyMedic/Poznavacky/releases/';
     private const RELEASE_IDS = array(
+        '4.1.1' => 75769088,
+        '4.0.1' => 48583462,
         '4.0' => 41734877,
         '3.2' => 22530404,
         '3.1' => 22501973,


### PR DESCRIPTION
Toto je potřeba pro zobrazování nových changelogů na stránkách.

Changelog pro verze 4.0.1 and 4.1.1.
(Verze 4.1 je bez changelogu a releasu)