### PR TITLE
Fix bugu při ukládání poznávaček bez přírodnin

### DIFF
--- a/Models/Processors/GroupEditor.php
+++ b/Models/Processors/GroupEditor.php
@@ -362,7 +362,7 @@ class GroupEditor
                 )); //Tohle se provede pro každou přírodninu, ale asi se nedá nic dělat
             }
             //Aktualizuj počet obrázků u části
-            Db::executeQuery('UPDATE casti SET obrazky = (SELECT SUM(prirodniny.obrazky) FROM prirodniny WHERE prirodniny.prirodniny_id IN (SELECT prirodniny_casti.prirodniny_id FROM prirodniny_casti WHERE prirodniny_casti.casti_id = ?)) WHERE casti.casti_id = ?',
+            Db::executeQuery('UPDATE casti SET obrazky = COALESCE((SELECT SUM(prirodniny.obrazky) FROM prirodniny WHERE prirodniny.prirodniny_id IN (SELECT prirodniny_casti.prirodniny_id FROM prirodniny_casti WHERE prirodniny_casti.casti_id = ?)), 0) WHERE casti.casti_id = ?',
                 array($part->getId(), $part->getId()));
         }
         


### PR DESCRIPTION
Poznávačka nešla uložit, protože se do databázového pole pro počet obrázků v části ukládalo NULL namísto 0 (počítal se součet z prázdného výsledku poddotazu).

Do chybového logu poté přicházela následující chyba:
```
[YYYY-MM-DD hh:mm:ss] ERROR Uživatel s ID [REDACTED] odeslal z IP adresy [REDACTED] požadavek na úpravu poznávačky s ID [REDACTED] patřící do třídy s ID [REDACTED], ale uložení změn zabránila neočekávaná chyba: Database query wasn't executed successfully.; úpravy byly popsány následujícím JSON řetězcem: {"name":"[REDACTED]","parts":[{"name":"[REDACTED]","naturals":[]}]} 
```