### PR TITLE
Povolení správy členů u veřejných tříd

### DIFF
--- a/Models/DatabaseItems/ClassObject.php
+++ b/Models/DatabaseItems/ClassObject.php
@@ -558,18 +558,6 @@ class ClassObject extends Folder
     {
         $this->loadIfNotLoaded($this->status);
 
-        if ($this->status == self::CLASS_STATUS_PUBLIC) {
-            //Nelze odstranit člena z veřejné třídy
-            (new Logger())->warning('Uživatel s ID {userId} se pokusil ze třídy s ID {classId} odebrat uživatele s ID {kickedUserId} z IP adresy {ip}, avšak tato třída je nastavena jako veřejná',
-                array(
-                    'userId' => UserManager::getId(),
-                    'classId' => $this->getId(),
-                    'kickedUserId' => $userId,
-                    'ip' => $_SERVER['REMOTE_ADDR']
-                ));
-            throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_KICK_USER_PUBLIC_CLASS);
-        }
-
         $this->loadIfNotLoaded($this->admin);
 
         if ($userId === $this->admin->getId()) {

--- a/Models/DatabaseItems/ClassObject.php
+++ b/Models/DatabaseItems/ClassObject.php
@@ -418,18 +418,6 @@ class ClassObject extends Folder
     {
         $this->loadIfNotLoaded($this->id);
 
-        //Zkontroluj, zda tato třída není veřejná
-        if ($this->status === self::CLASS_STATUS_PUBLIC) {
-            (new Logger())->warning('Uživatel s ID {userId} se pokusil z IP adresy {ip} odeslat pozvánku do třídy s ID {classId} pro uživatele se jménem {invitedUserName}, avšak daná třída je nastavena jako veřejná',
-                array(
-                    'userId' => UserManager::getId(),
-                    'ip' => $_SERVER['REMOTE_ADDR'],
-                    'classId' => $this->getId(),
-                    'invitedUserName' => $userName
-                ));
-            throw new AccessDeniedException(AccessDeniedException::REASON_MANAGEMENT_INVITE_USER_PUBLIC_CLASS);
-        }
-
         //Konstrukce objektu uživatele
         $result = Db::fetchQuery('SELECT '.User::COLUMN_DICTIONARY['id'].','.User::COLUMN_DICTIONARY['name'].','.
             User::COLUMN_DICTIONARY['email'].','.User::COLUMN_DICTIONARY['lastLogin'].','.

--- a/Models/Exceptions/AccessDeniedException.php
+++ b/Models/Exceptions/AccessDeniedException.php
@@ -101,7 +101,6 @@ class AccessDeniedException extends Exception
     public const REASON_MANAGEMENT_ACCESS_CHANGE_INVALID_CODE = self::REASON_NEW_CLASS_REQUEST_INVALID_CODE;
     public const REASON_MANAGEMENT_ACCESS_CHANGE_INVALID_STATUS = 'Zvolený status není platný';
     public const REASON_MANAGEMENT_INVITE_USER_UNKNOWN_USER = 'Uživatel nebyl nalezen';
-    public const REASON_MANAGEMENT_INVITE_USER_PUBLIC_CLASS = 'Pozvánky do veřejné třídy nelze vytvářet';
     public const REASON_MANAGEMENT_INVITE_USER_DEMO_ACCOUNT = 'Do své třídy nemůžeš pozvat demo účet';
     public const REASON_MANAGEMENT_INVITE_USER_ALREADY_MEMBER = 'Tento uživatel je již členem této třídy';
     public const REASON_MANAGEMENT_KICK_USER_CANT_SELF = 'Jako správce této třídy se nemůžeš sám odebrat';

--- a/Models/Exceptions/AccessDeniedException.php
+++ b/Models/Exceptions/AccessDeniedException.php
@@ -104,7 +104,6 @@ class AccessDeniedException extends Exception
     public const REASON_MANAGEMENT_INVITE_USER_PUBLIC_CLASS = 'Pozvánky do veřejné třídy nelze vytvářet';
     public const REASON_MANAGEMENT_INVITE_USER_DEMO_ACCOUNT = 'Do své třídy nemůžeš pozvat demo účet';
     public const REASON_MANAGEMENT_INVITE_USER_ALREADY_MEMBER = 'Tento uživatel je již členem této třídy';
-    public const REASON_MANAGEMENT_KICK_USER_PUBLIC_CLASS = 'Z této třídy nelze odebrat žádného člena';
     public const REASON_MANAGEMENT_KICK_USER_CANT_SELF = 'Jako správce této třídy se nemůžeš sám odebrat';
     public const REASON_MANAGEMENT_KICK_USER_NOT_A_MEMBER = 'Tento uživatel není členem této třídy';
     public const REASON_MANAGEMENT_NEW_GROUP_DUPLICATE_NAME = 'Poznávačka s tímto nebo velmi podobným názvem již ve tvé třídě existuje';


### PR DESCRIPTION
Vzhledem k tomu, že bylo zavedeno nastavení umožňující limitování přidávání obrázků do veřejných tříd, dává smysl znovu-povolení správy členství i u veřejných tříd.

V nastavení veřejných tříd je proto nyní možné opět:
1. Odesílat nové pozvánky
2. Odstraňovat členství u uživatelů, kteří jsou členy dané třídy

resolves #253 