### PR TITLE
E-mail pro obnovu hesla obsahuje odkaz i textově

### DIFF
--- a/Views/EmailTemplates/passwordRecovery.phtml
+++ b/Views/EmailTemplates/passwordRecovery.phtml
@@ -121,7 +121,8 @@ table[class=body] .article {
                     <tr>
                       <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">
                         <h2 style="color: #000000; font-family: sans-serif; font-weight: 400; line-height: 1.4; margin: 0; margin-bottom: 30px;">Žádost o obnovu hesla</h2>
-                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Pro obnovení svého hesla klikni na tento odkaz: <a href="<?= $recoveryLink ?>" style="color: #405d27; text-decoration: underline;">OBNOVIT HESLO</a></p>
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 5px;">Pro obnovení svého hesla klikni na tento odkaz: <a href="<?= $recoveryLink ?>" style="color: #405d27; text-decoration: underline;">OBNOVIT HESLO</a></p>
+                        <p style="font-family: sans-serif; font-size: 10px; font-weight: normal; margin: 0; margin-bottom: 15px;">Pokud odkaz výše nefunguje, zkopírujte do svého prohlížeče tuto URL adresu:<br><code style="background-color: #ccc;"><?= $recoveryLink ?></code>.</p>
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Tento odkaz bude platný po následujících 24 hodin, nebo do odeslání žádosti o nový kód.</p>
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px; color: #aa0000;"><span style="font-weight: bold;">DŮLEŽITÉ: </span>Tento e-mail nikomu nepřeposílej! Mohl*a by získat přístup k tvému účtu.</p>
                         <br>


### PR DESCRIPTION
Zjistil jsem, že v některých e-mailových klientech (např. v Thunderbirdu) je odkaz "OBNOVIT HESLO" neklikatelný. Takto si uživatel prostě zkopíruje odkaz do adresního řádku a hotovo.

Teoreticky by mohl být problém i s odkazy v ostatních e-mailech, ale tam nebývají odkazy až tak kritické.