### PR TITLE
Oprava bugu znemožňujícího drobné úpravy v názvech a jménech uživatelů/tříd/poznávaček/částí

### DIFF
--- a/Models/DatabaseItems/ClassObject.php
+++ b/Models/DatabaseItems/ClassObject.php
@@ -794,7 +794,7 @@ class ClassObject extends Folder
         //Kontrola dostupnosti jména (konkrétně URL adresy)
         $url = $this->generateUrl($newName);
         try {
-            $validator->checkUniqueness($url, DataValidator::TYPE_CLASS_URL);
+            $validator->checkUniqueness($url, DataValidator::TYPE_CLASS_URL, $this->getId());
         } catch (InvalidArgumentException $e) {
 
             (new Logger())->notice('Uživatel s ID {userId} se pokusil zažádat o změnu názvu třídy s ID {classId} na {newName} z IP adresy {ip}, avšak třída se stejnou URL reprezentací názvu již existuje',

--- a/Models/DatabaseItems/LoggedUser.php
+++ b/Models/DatabaseItems/LoggedUser.php
@@ -138,7 +138,7 @@ class LoggedUser extends User
         
         //Kontrola dostupnosti jména
         try {
-            $validator->checkUniqueness($newName, DataValidator::TYPE_USER_NAME);
+            $validator->checkUniqueness($newName, DataValidator::TYPE_USER_NAME, $this->getId());
         } catch (InvalidArgumentException $e) {
             (new Logger())->notice('Uživatel s ID {userId} se pokusil odeslat žádost o změnu jména z IP adresy {ip}, avšak požadované jméno nebylo unikátní',
                 array('userId' => UserManager::getId(), 'ip' => $_SERVER['REMOTE_ADDR']));
@@ -294,7 +294,7 @@ class LoggedUser extends User
             try {
                 $validator->checkLength($newEmail, DataValidator::USER_EMAIL_MIN_LENGTH,
                     DataValidator::USER_EMAIL_MAX_LENGTH, DataValidator::TYPE_USER_EMAIL);
-                $validator->checkUniqueness($newEmail, DataValidator::TYPE_USER_EMAIL);
+                $validator->checkUniqueness($newEmail, DataValidator::TYPE_USER_EMAIL, $this->getId());
             } catch (RangeException $e) {
                 (new Logger())->notice('Uživatel s ID {userId} se pokusil změnit svou e-mailovou adresu z IP adresy {ip}, avšak nová e-mailová adresa byla příliš dlouhá',
                     array('userId' => UserManager::getId(), 'ip' => $_SERVER['REMOTE_ADDR']));

--- a/Models/Processors/GroupAdder.php
+++ b/Models/Processors/GroupAdder.php
@@ -62,7 +62,7 @@ class GroupAdder
         $validator = new DataValidator();
         $url = Folder::generateUrl($groupName);
         try {
-            $validator->checkUniqueness($url, DataValidator::TYPE_GROUP_URL, $this->class);
+            $validator->checkUniqueness($url, DataValidator::TYPE_GROUP_URL, null, $this->class);
         } catch (InvalidArgumentException $e) {
             (new Logger())->notice('Uživatel s ID {userId} se pokusil přidat do třídy s ID {classId} z IP adresy {ip} novou poznávačku s názvem {groupName}, avšak poznávačka se stejnou URL reprezentací se v dané třídě již nachází',
                 array(

--- a/Models/Processors/NaturalEditor.php
+++ b/Models/Processors/NaturalEditor.php
@@ -86,7 +86,7 @@ class NaturalEditor
         }
         
         try {
-            $validator->checkUniqueness($newName, DataValidator::TYPE_NATURAL_NAME, $this->class);
+            $validator->checkUniqueness($newName, DataValidator::TYPE_NATURAL_NAME, $natural->getId(), $this->class);
         } catch (InvalidArgumentException $e) {
             (new Logger())->warning('Uživatel s ID {userId} se pokusil ve třídě s ID {classId} přejmenovat přírodninu s ID {naturalId} na {newName} z IP adresy {ip}, avšak neuspěl kvůli neunikátnímu názvu',
                 array(


### PR DESCRIPTION
DataValidator nyní může ignorovat shodnou URL u záznamu s daným ID.