### PR TITLE
URL-probing honeypot

### DIFF
--- a/Controllers/HoneypotController.php
+++ b/Controllers/HoneypotController.php
@@ -1,0 +1,26 @@
+<?php
+namespace Poznavacky\Controllers;
+
+use Poznavacky\Models\Logger;
+
+/**
+ * Kontroler starající se o vypsání úvodní stránky webu
+ * @author Jan Štěch
+ */
+class HoneypotController extends SynchronousController
+{
+    
+    /**
+     * Metoda nastavující hlavičku stránky a pohled k zobrazení
+     * @param array $parameters Parametry pro kontroler (nevyužíváno)
+     * @see SynchronousController::process()
+     */
+    public function process(array $parameters): void
+    {
+        file_put_contents('.htaccess', 'Deny from '.$_SERVER['REMOTE_ADDR'].PHP_EOL, FILE_APPEND | LOCK_EX); //Toto fakt není ideální, přímé upravování .htaccess je asi ta největší zrůdnost, co jsem kdy naprogramoval, ale prozartím to bude fungovat. Ideálně by se ten blacklist měl sestavovat v nějakém odděleném textovém souboru a .htaccess by jej měl načítat.
+        (new Logger())->info('Nepřihlášený uživatel přistupující na server z IP adresy {ip} byl přidán na blacklist IP adres kvůli pokusu přisoupit k (neexistujícímu) souboru .env.',
+                array('ip' => $_SERVER['REMOTE_ADDR']));
+        exit('You have been permanently blocked for URL-probing.'); //Tohle také není úplně elegantní. Ale hej, tohle je jenom pro roboty a hackery...
+    }
+}
+

--- a/routes.ini
+++ b/routes.ini
@@ -55,6 +55,8 @@ report-action=ReportAction
 account-settings=AccountSettings
 account-update=AccountUpdate
 
+.env=Honeypot
+
 [Routes]
 ; Seznam všech podporovaných URL cest
 ; Klíči jsou URL cesty, ve kterých jsou proměnné nahrazeny <x> značkami
@@ -122,6 +124,8 @@ account-update=AccountUpdate
 
 /menu/account-settings=AccountSettings
 /menu/account-update=AccountUpdate
+
+/.env=Honeypot
 
 [Selections]
 ; Seznam indexů pole $_SESSION['selection'], jejichž hodnoty se mají při použití určité cesty aktualizovat


### PR DESCRIPTION
Resolves #299 

Prozatím odchytáváme pouze dotazy na /.env. V budoucnu to můžeme rozšířit.

Byl přidán velice krátký kontroler (s exit()), který při vyvolání skrze routes.ini načtené v index.php přidá IP adresu aktuálního uživatele do blacklistu v .htaccess. To není úplně ideální, ale prozatím to funguje (viz komentáře v kódu).